### PR TITLE
minor fix, added null check after parseNodeList call before calling node...

### DIFF
--- a/src/main/java/com/redhat/drupal/fields/IdListField.java
+++ b/src/main/java/com/redhat/drupal/fields/IdListField.java
@@ -32,6 +32,9 @@ public abstract class IdListField extends Field {
 
 		// Parse the list of IDs into the entityIds list
 		NodeList nodes = parseNodeList("//" + this.machineName + "/und/item", xml);
+                if (null == nodes){
+                    return;
+                }
 		for (int i = 0; i < nodes.getLength(); i++) {
 			Node node = nodes.item(i);
 			Integer value = Utils.safeNewInteger(parseField("./" + this.itemValueElementName, node));

--- a/src/main/java/com/redhat/drupal/fields/TermReferenceField.java
+++ b/src/main/java/com/redhat/drupal/fields/TermReferenceField.java
@@ -43,6 +43,9 @@ public class TermReferenceField extends Field {
 
 		// Parse the term elements into a new term
 		NodeList nodes = parseNodeList("//" + this.machineName + "/und/item", xml);
+                if (null == nodes){
+                    return;
+                }
 		for (int i = 0; i < nodes.getLength(); i++) {
 			Node node = nodes.item(i);
 			String name = parseField("./name", node);


### PR DESCRIPTION
...s.getLength()

Was getting an NPE if not passing in values for these objects in the XML.  Not sure if this is _how_ you want to do it, but it's an easy fix.
